### PR TITLE
allow multiple hammer managers to be used on the same element

### DIFF
--- a/propagating.js
+++ b/propagating.js
@@ -71,7 +71,9 @@
 
     // attach to DOM element
     var element = hammer.element;
-    element.hammer = wrapper;
+
+    if(!element.hammer) element.hammer = [];
+    element.hammer.push(wrapper);
 
     // register an event to catch the start of a gesture and store the
     // target in a singleton
@@ -152,7 +154,10 @@
 
     wrapper.destroy = function () {
       // Detach from DOM element
-      delete hammer.element.hammer;
+      var hammers = hammer.element.hammer;
+      var idx = hammers.indexOf(wrapper);
+      if(idx !== -1) hammers.splice(idx,1);
+      if(!hammers.length) delete hammer.element.hammer;
 
       // clear all handlers
       wrapper._handlers = {};
@@ -199,13 +204,15 @@
       // propagate over all elements (until stopped)
       var elem = _firstTarget;
       while (elem && !stopped) {
-        var _handlers = elem.hammer && elem.hammer._handlers[event.type];
-        if (_handlers) {
-          for (var i = 0; i < _handlers.length && !stopped; i++) {
-            _handlers[i](event);
+        if(elem.hammer){
+          var _handlers;
+          for(var k = 0; k < elem.hammer.length; k++){
+            _handlers = elem.hammer[k]._handlers[event.type];
+            if(_handlers) for (var i = 0; i < _handlers.length && !stopped; i++) {
+              _handlers[i](event);
+            }
           }
         }
-
         elem = elem.parentNode;
       }
     }

--- a/propagating.js
+++ b/propagating.js
@@ -198,6 +198,15 @@
         stopped = true;
       };
 
+      //wrap the srcEvent's stopPropagation to also stop hammer propagation:
+      var srcStop = event.srcEvent.stopPropagation;
+      if(typeof srcStop == "function") {
+        event.srcEvent.stopPropagation = function(){
+          srcStop();
+          event.stopPropagation();
+        }
+      }
+
       // attach firstTarget property to the event
       event.firstTarget = _firstTarget;
 


### PR DESCRIPTION
I wrapped your plugin such that all uses of Hammer sitewide are wrapped in your plugin (and thus behave sensibly). I did however notice that when attaching multiple hammer managers to an element (which is the case if you use the angular-hammer plugin in conjunction with JS to attach hammer events to an element) led to things not working as expected. This change seems to fix that.

In addition, I wrapped event.srcEvent.stopPropagation if it exists, to ensure that using it will also act as expected.
