### PR TITLE
switch to @egjs/hammerjs fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # propagating-hammerjs
 
-Extend [hammer.js](https://github.com/hammerjs/hammer.js) v2 with event propagation.
+Extend [hammer.js](https://hammerjs.github.io/) (v2) with event propagation.
+
+We use the [@egjs/hammerjs](https://www.npmjs.com/package/@egjs/hammerjs) fork because [hammer.js](https://www.npmjs.com/package/hammerjs) is [not maintained anymore](https://github.com/hammerjs/hammer.js/graphs/code-frequency).
 
 ## Features
 
@@ -16,7 +18,7 @@ Extend [hammer.js](https://github.com/hammerjs/hammer.js) v2 with event propagat
 ## Install
 
 ```sh
-npm install propagating-hammerjs
+npm install @egjs/hammerjs propagating-hammerjs
 ```
 
 ## Load
@@ -27,7 +29,7 @@ npm install propagating-hammerjs
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="https://unpkg.com/hammerjs@latest/hammer.js"></script>
+  <script src="https://unpkg.com/@egjs/hammerjs@latest/dist/hammer.js"></script>
   <script src="https://unpkg.com/propagating-hammerjs@latest/propagating.js"></script>
   <script>
     function init() {
@@ -43,7 +45,7 @@ npm install propagating-hammerjs
 ### Commonjs (e.g. Node.js, Browserify)
 
 ```js
-var Hammer = require('hammerjs');
+var Hammer = require('@egjs/hammerjs');
 var propagating = require('propagating-hammerjs');
 
 function init() {
@@ -85,8 +87,8 @@ More examples are available in the folder [/examples](./examples/).
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="node_modules/hammerjs/hammer.js"></script>
-  <script src="propagating.js"></script>
+  <script src="node_modules/@egjs/hammerjs/hammer.js"></script>
+  <script src="node_muludes/propagating-hammerjs/propagating.js"></script>
   <style>
     div     {border: 1px solid black;}
     #parent {width: 400px; height: 400px; background: lightgreen;}

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Basic usage</title>
-  <script src="../node_modules/hammerjs/hammer.js"></script>
+  <script src="../node_modules/@egjs/hammerjs/hammer.js"></script>
   <script src="../propagating.js"></script>
   <style>
     div     {border: 1px solid black;}

--- a/examples/extensive.html
+++ b/examples/extensive.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Extensive usage example</title>
-  <script src="../node_modules/hammerjs/hammer.js"></script>
+  <script src="../node_modules/@egjs/hammerjs/hammer.js"></script>
   <script src="../propagating.js"></script>
   <style>
     #parent {

--- a/examples/firstTarget.html
+++ b/examples/firstTarget.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Use event.firstTarget</title>
-  <script src="../node_modules/hammerjs/hammer.js"></script>
+  <script src="../node_modules/@egjs/hammerjs/hammer.js"></script>
   <script src="../propagating.js"></script>
   <style>
     div     {border: 1px solid black;}

--- a/examples/global.html
+++ b/examples/global.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Replace global hammer.js constructor</title>
-  <script src="../node_modules/hammerjs/hammer.js"></script>
+  <script src="../node_modules/@egjs/hammerjs/hammer.js"></script>
   <script src="../propagating.js"></script>
   <style>
     div     {border: 1px solid black;}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "rollup": "^2.29.0"
   },
-  "dependencies": {
-    "hammerjs": "^2.0.8"
+  "peerDependencies": {
+    "@egjs/hammerjs": "^2.0.17"
   }
 }


### PR DESCRIPTION
- Switch to the very widely used [@egjs/hammerjs fork](https://www.npmjs.com/package/@egjs/hammerjs) because [hammer.js](https://www.npmjs.com/package/hammerjs) is [not maintained anymore](https://github.com/hammerjs/hammer.js/graphs/code-frequency).
- define `hammerjs` as [peerDependencie](https://nodejs.org/es/blog/npm/peer-dependencies/#using-peer-dependencies) because it is expected but not imported (import, require) by the library itself.

(This should propably be merged/rebased after #15)