### PR TITLE
Use event.target in cases where _firstTarget has been removed from DOM

### DIFF
--- a/src/propagating.js
+++ b/src/propagating.js
@@ -2,15 +2,6 @@
 
 var _firstTarget = null; // singleton, will contain the target element where the touch event started
 
-function inDocument(el) {
-  var cur = el;
-  while (cur) {
-    if (cur.nodeType === Node.DOCUMENT_NODE) return true;
-    cur = cur.parentNode;
-  }
-  return false;
-}
-
 /**
  * Extend an Hammer.js instance with event propagation.
  *
@@ -205,7 +196,7 @@ export default function propagating(hammer, options) {
     event.firstTarget = _firstTarget;
 
     // propagate over all elements (until stopped)
-    var elem = inDocument(_firstTarget) ? _firstTarget : event.target;
+    var elem = _firstTarget.isConnected ? _firstTarget : event.target;
     while (elem && !stopped) {
       var elemHammer = elem.hammer;
       if(elemHammer){

--- a/src/propagating.js
+++ b/src/propagating.js
@@ -196,7 +196,7 @@ export default function propagating(hammer, options) {
     event.firstTarget = _firstTarget;
 
     // propagate over all elements (until stopped)
-    var elem = _firstTarget;
+    var elem = document.contains(_firstTarget) ? _firstTarget : event.target;
     while (elem && !stopped) {
       var elemHammer = elem.hammer;
       if(elemHammer){

--- a/src/propagating.js
+++ b/src/propagating.js
@@ -2,6 +2,15 @@
 
 var _firstTarget = null; // singleton, will contain the target element where the touch event started
 
+function inDocument(el) {
+  var cur = el;
+  while (cur) {
+    if (cur.nodeType === Node.DOCUMENT_NODE) return true;
+    cur = cur.parentNode;
+  }
+  return false;
+}
+
 /**
  * Extend an Hammer.js instance with event propagation.
  *
@@ -196,7 +205,7 @@ export default function propagating(hammer, options) {
     event.firstTarget = _firstTarget;
 
     // propagate over all elements (until stopped)
-    var elem = document.contains(_firstTarget) ? _firstTarget : event.target;
+    var elem = inDocument(_firstTarget) ? _firstTarget : event.target;
     while (elem && !stopped) {
       var elemHammer = elem.hammer;
       if(elemHammer){


### PR DESCRIPTION
I have a use case in vis-timeline where _firstTarget ends up getting removed from the DOM during a pan event. This causes the pan to stop immediately because it no longer a descendent of the hammer root element.